### PR TITLE
:package: deps: pnpm-workspaceにonlyBuiltDependenciesを設定する

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - frontend
   - backend
   - shared
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - ワークスペース構成を更新し、esbuild・sharp・workerd をビルド済み依存として扱う設定を追加。
  - 実行時の機能や挙動に変更はなく、ビルド環境の一貫性と安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->